### PR TITLE
Fixed PHP error 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,9 @@
 ### Added
 - Added in a function to get a converted value for the FacetWP Price slider when indexing and using multi currency.
 
+### Fixed
+- Fixed PHP error `money_format() expects parameter 2 to be float, string given`.
+
 ### Security
 - Updating dependencies to prevent vulnerabilities.
 - General testing to ensure compatibility with latest WordPress version (5.4).

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -193,7 +193,7 @@ class Frontend {
 
 			// Work out the other tags
 			$currency = '<span class="currency-icon ' . mb_strtolower( lsx_currencies()->base_currency ) . '">' . lsx_currencies()->base_currency . '</span>';
-			$amount = '<span class="value" data-price-' . lsx_currencies()->base_currency . '="' . trim( str_replace( array( '$', 'USD' ), '', money_format( $money_format, ltrim( rtrim( $value ) ) ) ) ) . '" ' . $additional_html . '>' . str_replace( array( '$', 'USD' ), '', money_format( $money_format, ltrim( rtrim( $value ) ) ) ) . '</span>';
+			$amount = '<span class="value" data-price-' . lsx_currencies()->base_currency . '="' . trim( str_replace( array( '$', 'USD' ), '', money_format( (float) $money_format, ltrim( rtrim( $value ) ) ) ) ) . '" ' . $additional_html . '>' . str_replace( array( '$', 'USD' ), '', money_format( $money_format, ltrim( rtrim( $value ) ) ) ) . '</span>';
 
 			// Check for a price type and add that in.
 			$price_type = get_post_meta( get_the_ID(), 'price_type', true );


### PR DESCRIPTION
### Description of the Change

This code is for fixing the PHP error  `money_format() expects parameter 2 to be float, string given`.

### Benefits

Better performance.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

- Fixed PHP error `money_format() expects parameter 2 to be float, string given`.

