### PR TITLE
LSX Currencies 2.0.0: navigation-based currency switcher + exchange-rate caching fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Change log
 
+## [Unreleased]
+
+### Fixed
+- Exchange rate fetching in `class-frontend.php` now persists rates via `get_option()`/`update_option()` instead of `set_transient()`/`get_transient()`, so a failed OpenExchangeRates API request can no longer wipe out the last known good rates — the cached values now only get overwritten on a successful response.
+- A new `lsx_currencies_rates_updated` option tracks the last successful fetch time and gates the refresh interval (24 hours), replacing the transient's built-in expiry which was previously set to 12 hours instead of the intended 24.
+
 ## [2.0.0] - 2026-06-12
 
 ### Added

--- a/classes/class-currencies.php
+++ b/classes/class-currencies.php
@@ -154,10 +154,15 @@ class Currencies {
 			$this->remove_decimals = (bool) $options['lsx_currencies_remove_decimals'];
 		}
 
-		if ( ! empty( $options['lsx_currencies_openexchange_api'] ) ) {
+		if ( defined( 'LSX_CURRENCIES_API_KEY' ) ) {
+			$this->app_id  = sanitize_text_field( LSX_CURRENCIES_API_KEY );
+		} else if ( ! empty( $options['lsx_currencies_openexchange_api'] ) ) {
 			$this->app_id  = sanitize_text_field( $options['lsx_currencies_openexchange_api'] );
-			$this->api_url = esc_url_raw( 'https://openexchangerates.org/api/latest.json?app_id=' . $this->app_id );
+		} else {
+			return false;
 		}
+
+		$this->api_url = esc_url_raw( 'https://openexchangerates.org/api/latest.json?app_id=' . $this->app_id );
 
 		$this->available_currencies = $this->get_available_currencies();
 		$this->currency_symbols     = $this->get_currency_symbols();

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -91,7 +91,7 @@ class Frontend {
 				} elseif ( is_object( $decoded ) && isset( $decoded->rates ) ) {
 					$this->rates         = $decoded->rates;
 					$this->rates_message = esc_html__( 'Success (new request).', 'lsx-currencies' );
-					set_transient( 'lsx_currencies_rates', $this->rates, 12 * HOUR_IN_SECONDS );
+					set_transient( 'lsx_currencies_rates', $this->rates, 24 * HOUR_IN_SECONDS );
 					do_action( 'lsx_currencies_rates_refreshed' );
 				} else {
 					$this->rates_message = esc_html__( 'Error: Invalid API response format.', 'lsx-currencies' );

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -69,12 +69,19 @@ class Frontend {
 	}
 
 	/**
-	 * Fetch exchange rates (cached for 12 hours) and resolve current currency.
+	 * Fetch exchange rates and resolve current currency.
+	 *
+	 * Rates are persisted in a regular option (not a transient) so a failed
+	 * API request can never wipe out the last known good values — we only
+	 * ever overwrite them on a successful response. A separate "updated at"
+	 * option gates how often we attempt a refresh (every 24 hours).
 	 */
 	public function set_defaults() {
-		$this->rates = get_transient( 'lsx_currencies_rates' );
+		$this->rates  = get_option( 'lsx_currencies_rates', false );
+		$last_updated = (int) get_option( 'lsx_currencies_rates_updated', 0 );
+		$needs_refresh = ( false === $this->rates ) || ( ( time() - $last_updated ) >= DAY_IN_SECONDS );
 
-		if ( false === $this->rates ) {
+		if ( $needs_refresh ) {
 			$api_url  = esc_url_raw( lsx_currencies()->api_url );
 			$response = wp_safe_remote_get( $api_url, array( 'timeout' => 10 ) );
 
@@ -91,7 +98,8 @@ class Frontend {
 				} elseif ( is_object( $decoded ) && isset( $decoded->rates ) ) {
 					$this->rates         = $decoded->rates;
 					$this->rates_message = esc_html__( 'Success (new request).', 'lsx-currencies' );
-					set_transient( 'lsx_currencies_rates', $this->rates, 24 * HOUR_IN_SECONDS );
+					update_option( 'lsx_currencies_rates', $this->rates, false );
+					update_option( 'lsx_currencies_rates_updated', time(), false );
 					do_action( 'lsx_currencies_rates_refreshed' );
 				} else {
 					$this->rates_message = esc_html__( 'Error: Invalid API response format.', 'lsx-currencies' );

--- a/src/blocks/currency-switcher/view.js
+++ b/src/blocks/currency-switcher/view.js
@@ -235,7 +235,7 @@
 
 	function init() {
 		if ( typeof fx !== 'undefined' ) {
-			fx.base  = 'USD';
+			fx.base  = params.base || 'USD';
 			fx.rates = params.rates || {};
 		}
 


### PR DESCRIPTION
## Summary
- Full 2.0.0 rewrite: Currency Switcher block restricted to `core/navigation`, mimicking `core/navigation-submenu` output with full Interactivity API support, Tour Operator settings integration, and removal of the legacy menu-injection switcher/shortcode/flag-icon functionality (see changelog.md for the complete 2.0.0 entry).
- Hotfix: exchange-rate fetching now persists via `get_option()`/`update_option()` instead of `set_transient()`/`get_transient()`, so a failed OpenExchangeRates request can no longer wipe out the last known good rates — cached values are only overwritten on a successful response, with a `lsx_currencies_rates_updated` option gating the 24-hour refresh interval.
- Changelog updated with an `Unreleased` entry documenting the caching fix.

## Test plan
- [ ] Confirm currency switcher block renders correctly inside `core/navigation` and matches `core/navigation-submenu` open/close behaviour
- [ ] Verify prices convert client-side on currency switch without a page reload
- [ ] Confirm exchange rates persist in `wp_options` (`lsx_currencies_rates`, `lsx_currencies_rates_updated`) and survive a simulated API failure
- [ ] Confirm rates refresh after 24 hours on next front-end page load
- [ ] Verify Tour Operator settings page shows currency/API key fields correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)